### PR TITLE
Issue openam#36 Remove dependency on ForgeRock Maven repositories

### DIFF
--- a/bloomfilter-core/pom.xml
+++ b/bloomfilter-core/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>forgerock-bloomfilter</artifactId>
-        <groupId>org.forgerock.commons</groupId>
+        <groupId>jp.openam.commons</groupId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -28,12 +28,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>jp.openam.commons</groupId>
             <artifactId>forgerock-util</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.commons.guava</groupId>
+            <groupId>jp.openam.commons.guava</groupId>
             <artifactId>forgerock-guava-hash</artifactId>
         </dependency>
         <dependency>

--- a/bloomfilter-core/pom.xml
+++ b/bloomfilter-core/pom.xml
@@ -13,13 +13,14 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>forgerock-bloomfilter</artifactId>
         <groupId>org.forgerock.commons</groupId>
-        <version>1.0.1</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bloomfilter-monitoring/pom.xml
+++ b/bloomfilter-monitoring/pom.xml
@@ -13,13 +13,14 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>forgerock-bloomfilter</artifactId>
         <groupId>org.forgerock.commons</groupId>
-        <version>1.0.1</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bloomfilter-monitoring/pom.xml
+++ b/bloomfilter-monitoring/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>forgerock-bloomfilter</artifactId>
-        <groupId>org.forgerock.commons</groupId>
+        <groupId>jp.openam.commons</groupId>
         <version>1.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -28,7 +28,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.forgerock.commons</groupId>
+            <groupId>jp.openam.commons</groupId>
             <artifactId>forgerock-bloomfilter-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -42,11 +42,10 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-bloomfilter.git</connection>
-        <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-bloomfilter.git</developerConnection>
-        <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-bloomfilter/browse</url>
-      <tag>1.0.1</tag>
-  </scm>
+        <connection>scm:git:https://github.com/openam-jp/forgerock-bloomfilter.git</connection>
+        <developerConnection>scm:git:git@github.com:openam-jp/forgerock-bloomfilter.git</developerConnection>
+        <url>https://github.com/openam-jp/forgerock-bloomfilter</url>
+    </scm>
 
     <properties>
         <hdrhistogram.version>2.1.4</hdrhistogram.version>
@@ -114,17 +113,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>forgerock-staging-repository</id>
-            <name>ForgeRock Release Repository</name>
-            <url>http://maven.forgerock.org/repo/releases</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -19,11 +19,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.forgerock</groupId>
+        <groupId>jp.openam</groupId>
         <artifactId>forgerock-parent</artifactId>
         <version>2.0.4</version>
     </parent>
-    <groupId>org.forgerock.commons</groupId>
+    <groupId>jp.openam.commons</groupId>
     <artifactId>forgerock-bloomfilter</artifactId>
     <version>1.0.2-SNAPSHOT</version>
     <name>ForgeRock Bloom Filters</name>
@@ -61,7 +61,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.forgerock.commons</groupId>
+                <groupId>jp.openam.commons</groupId>
                 <artifactId>forgerock-bom</artifactId>
                 <version>3.0.0</version>
                 <scope>import</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions Copyrighted 2019 Open Source Solution Technology Corporation
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -24,7 +25,7 @@
     </parent>
     <groupId>org.forgerock.commons</groupId>
     <artifactId>forgerock-bloomfilter</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
     <name>ForgeRock Bloom Filters</name>
     <description>Thread-safe implementations of scalable and rolling Bloom Filters.</description>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>jp.openam</groupId>
         <artifactId>forgerock-parent</artifactId>
-        <version>2.0.4</version>
+        <version>2.0.7-SNAPSHOT</version>
     </parent>
     <groupId>jp.openam.commons</groupId>
     <artifactId>forgerock-bloomfilter</artifactId>
@@ -63,7 +63,7 @@
             <dependency>
                 <groupId>jp.openam.commons</groupId>
                 <artifactId>forgerock-bom</artifactId>
-                <version>3.0.0</version>
+                <version>4.1.2-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
## Analysis
This project is Bloom Filters implementations for ForgeRock projects.

In order to fix openam-jp/openam#36, this project also needs modification.

## Solution

* Remove ForgeRock repository tags in pom.xml
* Change Maven groupId
* Adjust maven dependency

## Install/Update
N/A

## Compatibility
N/A

## Performance
N/A

## I18N
N/A

## Testing
```
$ mvn install -f forgerock-parent
$ mvn install -f forgerock-bom
$ mvn install -f forgerock-build-tools
$ mvn install -f forgerock-i18n-framework
$ mvn install -f forgerock-guice
$ mvn install -f forgerock-guava
$ mvn install -f forgerock-ui
$ mvn install -DskipTests -f forgerock-commons
$ mvn install -f forgerock-bloomfilter
```

## Regression testing
N/A