### PR TITLE
Issue openam#33 Upgrade unit testing frameworks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Analysis

openam-jp/openam#33

OpenAM uses the following unit testing frameworks.

* TestNG 6.8.5
* AssertJ 2.1.0
* Mockito 1.9.5
* EasyMock 3.2
* Powermock 1.5
* JUnit 4.10

Some frameworks do not support Java 11.
For example, Mockito supports Java 11 from version 2.20.1.


## Solution
Upgrade unit testing frameworks. Then, tests will pass in Java 8 environment.
- TestNG 6.14.3
- AssertJ 3.13.2
- Mockito 2.28.2
- EasyMoch 4.0.2
- PowerMock 2.0.2
- Junit 4.12


## Install/Update
This fix relies on aggregation of dependencies on the BOM.
The unit testing frameworks are updated by BOM.
To apply the fix, get the modules in the following order and build them.

- forgerock-parent
- forgerock-bom
- forgerock-build-tools
- forgerock-i18n-framework
- forgerock-guice
- forgerock-ui
- forgerock-guava
- forgerock-commons
- forgerock-persistit
- forgerock-bloomfilter
- opendj-sdk
- opendj
- openam


## Regression testing
Test results from testframework have not changed.
